### PR TITLE
This fixes #98

### DIFF
--- a/1.12/src/main/java/com/github/fnar/minecraft/WorldEditor1_12.java
+++ b/1.12/src/main/java/com/github/fnar/minecraft/WorldEditor1_12.java
@@ -30,14 +30,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.tileentity.MobSpawnerBaseLogic;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.tileentity.TileEntityBed;
-import net.minecraft.tileentity.TileEntityChest;
-import net.minecraft.tileentity.TileEntityFlowerPot;
-import net.minecraft.tileentity.TileEntityLockableLoot;
-import net.minecraft.tileentity.TileEntityMobSpawner;
-import net.minecraft.tileentity.TileEntitySkull;
+import net.minecraft.tileentity.*;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -338,7 +331,7 @@ public class WorldEditor1_12 implements WorldEditor {
     if (tileEntity == null) {
       return;
     }
-    if (!(tileEntity instanceof TileEntityLockableLoot)) {
+    if (!(tileEntity instanceof TileEntityLockableLoot) && !(tileEntity instanceof TileEntityFurnace) && !(tileEntity instanceof TileEntityBrewingStand)) {
       return;
     }
     ItemStack forgeItemStack = null;
@@ -347,8 +340,18 @@ public class WorldEditor1_12 implements WorldEditor {
     } catch (CouldNotMapItemException e) {
       logger.error(e);
     }
+    if (forgeItemStack == null) {
+      return;
+    }
+    
     try {
-      ((TileEntityLockableLoot) tileEntity).setInventorySlotContents(slot, forgeItemStack);
+      if (tileEntity instanceof TileEntityLockableLoot) {
+        ((TileEntityLockableLoot) tileEntity).setInventorySlotContents(slot, forgeItemStack);
+      } else if (tileEntity instanceof TileEntityFurnace) {
+        ((TileEntityFurnace) tileEntity).setInventorySlotContents(slot, forgeItemStack);
+      } else {
+        ((TileEntityBrewingStand) tileEntity).setInventorySlotContents(slot, forgeItemStack);
+      }
     } catch (NullPointerException nullPointerException) {
       logger.error("Could not place item {} at position {}. BlockState at pos: {}.", forgeItemStack, coord, getBlockStateAt(coord));
     }

--- a/roguelike-core/src/main/java/com/github/fnar/minecraft/block/decorative/FurnaceBlock.java
+++ b/roguelike-core/src/main/java/com/github/fnar/minecraft/block/decorative/FurnaceBlock.java
@@ -1,0 +1,10 @@
+package com.github.fnar.minecraft.block.decorative;
+
+public class FurnaceBlock {
+    
+    public static class Slot {
+        public static final int TO_SMELT = 0;
+        public static final int FUEL = 1;
+        public static final int RESULT = 2;
+    }
+}

--- a/roguelike-core/src/main/java/greymerk/roguelike/dungeon/rooms/prototype/BedRoomRoom.java
+++ b/roguelike-core/src/main/java/greymerk/roguelike/dungeon/rooms/prototype/BedRoomRoom.java
@@ -1,5 +1,6 @@
 package greymerk.roguelike.dungeon.rooms.prototype;
 
+import com.github.fnar.minecraft.block.decorative.FurnaceBlock;
 import com.google.common.collect.Lists;
 
 import com.github.fnar.minecraft.block.BlockType;
@@ -210,7 +211,7 @@ public class BedRoomRoom extends BaseRoom {
 
     RldItemStack coal = Material.Type.COAL.asItemStack().withCount(2 + random().nextInt(3));
 
-    worldEditor.setItem(furnace, WorldEditor.FURNACE_FUEL_SLOT, coal);
+    worldEditor.setItem(furnace, FurnaceBlock.Slot.FUEL, coal);
   }
 
 }


### PR DESCRIPTION
Turns out ``TileEntityFurnace`` and ``TileEntityBrewingStand`` don't extend ``TileEntityLockableLoot``, but ``TileEntityLockable``.

But since ``TileEntityLockable`` doesn't have the method ``setInventorySlotContents``, I had to manually check if ``tileEntity`` is an instance of ``TileEntityFurnace`` or ``TileEntityBrewingStand`` and call ``setInventorySlotContents`` accordingly.

Moonshine correctly generated in B-Team's Hideout, and coal was found inside the Bedroom's Furnace 😄  
  
If you know a more elegant way to implement this fix, feel free to do so and don't merge this PR.  

We're getting closer and closer to perfection! 🎉