### PR TITLE
Added an Eventbus to the generator.

### DIFF
--- a/1.12/src/main/java/com/github/fnar/roguelike/Roguelike.java
+++ b/1.12/src/main/java/com/github/fnar/roguelike/Roguelike.java
@@ -1,6 +1,7 @@
 package com.github.fnar.roguelike;
 
 import com.github.fnar.roguelike.command.RoguelikeCommand1_12;
+import com.github.fnar.roguelike.events.SubscriberTester;
 import com.github.fnar.roguelike.worldgen.DungeonGenerator1_12;
 
 import net.minecraft.command.ICommandManager;
@@ -43,6 +44,7 @@ public class Roguelike {
   public void modInit(FMLInitializationEvent event) {
     MinecraftForge.EVENT_BUS.register(new EntityJoinWorld1_12());
     MinecraftForge.EVENT_BUS.register(new ItemTooltip());
+    MinecraftForge.EVENT_BUS.register(SubscriberTester.class);
   }
 
   @EventHandler

--- a/1.12/src/main/java/com/github/fnar/roguelike/events/StructureGenerationEvent.java
+++ b/1.12/src/main/java/com/github/fnar/roguelike/events/StructureGenerationEvent.java
@@ -1,0 +1,82 @@
+package com.github.fnar.roguelike.events;
+
+import greymerk.roguelike.dungeon.settings.SettingIdentifier;
+import greymerk.roguelike.worldgen.Coord;
+import lombok.NonNull;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.WorldEvent;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+public class StructureGenerationEvent extends WorldEvent implements GenerationEvents {
+
+    protected SettingIdentifier identifier;
+    protected Coord coord;
+    protected World world;
+    protected int dimension;
+
+    public StructureGenerationEvent(World world, int dimension) {
+        super(world);
+        this.world = world;
+        this.dimension = dimension;
+    }
+
+    public StructureGenerationEvent(World world, @NonNull SettingIdentifier id, @NonNull Coord coord) {
+        super(world);
+        this.identifier = id;
+        this.coord = coord;
+    }
+
+    @NonNull
+    public SettingIdentifier getIdentifier() {
+        return identifier;
+    }
+
+    @NonNull
+    public Coord getCoord() {
+        return coord;
+    }
+
+    public World getWorld() {
+        return world;
+    }
+
+    public int getDimension() {
+        return dimension;
+    }
+
+    @Override
+    public void eventPre(SettingIdentifier id, Coord coord) {
+        MinecraftForge.EVENT_BUS.post(new StructureGenerationEvent.Pre(world, id, coord));
+    }
+
+    @Override
+    public void eventPost(SettingIdentifier id, Coord coord) {
+        MinecraftForge.EVENT_BUS.post(new StructureGenerationEvent.Post(world, id, coord));
+    }
+
+    @Override
+    public boolean eventSuggest(SettingIdentifier id, Coord coord) {
+        return !MinecraftForge.EVENT_BUS.post(new SuggestGen(world, id, coord));
+    }
+
+    @Cancelable
+    public static class SuggestGen extends StructureGenerationEvent {
+        public SuggestGen(World world, @NonNull SettingIdentifier id, @NonNull Coord coord) {
+            super(world, id, coord);
+        }
+    }
+
+
+    public static class Pre extends StructureGenerationEvent {
+        public Pre(World world, @NonNull SettingIdentifier id, @NonNull Coord coord) {
+            super(world, id, coord);
+        }
+    }
+
+    public static class Post extends StructureGenerationEvent {
+        public Post(World world, @NonNull SettingIdentifier id, @NonNull Coord coord) {
+            super(world, id, coord);
+        }
+    }
+}

--- a/1.12/src/main/java/com/github/fnar/roguelike/events/StructurePartsGenerationEvent.java
+++ b/1.12/src/main/java/com/github/fnar/roguelike/events/StructurePartsGenerationEvent.java
@@ -1,0 +1,52 @@
+package com.github.fnar.roguelike.events;
+
+import greymerk.roguelike.dungeon.settings.SettingIdentifier;
+import lombok.NonNull;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.WorldEvent;
+
+import java.util.List;
+
+public class StructurePartsGenerationEvent extends WorldEvent implements GenerationPartsEvent {
+
+    protected World world;
+    protected List<Float> coords;
+    protected SettingIdentifier identifier;
+    protected int dimension;
+
+    public StructurePartsGenerationEvent(World world, int dimension) {
+        super(world);
+        this.world = world;
+        this.dimension = dimension;
+    }
+
+    public StructurePartsGenerationEvent(World world, @NonNull SettingIdentifier id, @NonNull List<Float> coords) {
+        super(world);
+        this.identifier = id;
+        this.coords = coords;
+    }
+
+    @NonNull
+    public SettingIdentifier getIdentifier() {
+        return identifier;
+    }
+
+    @NonNull
+    public List<Float> getCoords() {
+        return coords;
+    }
+
+    public World getWorld() {
+        return world;
+    }
+
+    public int getDimension() {
+        return dimension;
+    }
+
+    @Override
+    public void eventParts(SettingIdentifier id, List<Float> coords) {
+        MinecraftForge.EVENT_BUS.post(new StructurePartsGenerationEvent(world, id, coords));
+    }
+}

--- a/1.12/src/main/java/com/github/fnar/roguelike/events/SubscriberTester.java
+++ b/1.12/src/main/java/com/github/fnar/roguelike/events/SubscriberTester.java
@@ -1,0 +1,35 @@
+package com.github.fnar.roguelike.events;
+
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class SubscriberTester {
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void onStructureGenerationPost(StructureGenerationEvent.Post event) {
+        System.out.println("EVENT POST");
+        System.out.println(event.getIdentifier());
+        System.out.println(event.getCoord());
+        System.out.println("-----------");
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void onStructureGenerationPre(StructureGenerationEvent.Pre event) {
+        System.out.println("EVENT PRE");
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void onStructureGenerationSuggest(StructureGenerationEvent.SuggestGen event) {
+        System.out.println("EVENT SUGGEST");
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void onStructurePartsGeneration(StructurePartsGenerationEvent event) {
+        System.out.println("EVENT PARTS");
+        System.out.println("DUNGEON ID:" + event.getIdentifier());
+        System.out.println("COORDS: " + event.getCoords());
+        System.out.println("WORLD:" + event.getWorld());
+        System.out.println("DIMENSION:" + event.getDimension());
+    }
+
+}

--- a/1.12/src/main/java/com/github/fnar/roguelike/worldgen/DungeonGenerator1_12.java
+++ b/1.12/src/main/java/com/github/fnar/roguelike/worldgen/DungeonGenerator1_12.java
@@ -1,6 +1,10 @@
 package com.github.fnar.roguelike.worldgen;
 
 import com.github.fnar.minecraft.WorldEditor1_12;
+import com.github.fnar.roguelike.events.GenerationEvents;
+import com.github.fnar.roguelike.events.GenerationPartsEvent;
+import com.github.fnar.roguelike.events.StructureGenerationEvent;
+import com.github.fnar.roguelike.events.StructurePartsGenerationEvent;
 import com.github.fnar.util.SafeRunnable;
 
 import net.minecraft.world.World;
@@ -19,7 +23,9 @@ public class DungeonGenerator1_12 implements IWorldGenerator {
   public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider) {
     SafeRunnable.run(() -> {
       WorldEditor editor = new WorldEditor1_12(world);
-      Dungeon.generateInChunkIfPossible(editor, chunkX, chunkZ);
+      GenerationEvents eventBus = new StructureGenerationEvent(world, editor.getDimension());
+      GenerationPartsEvent partsEventBus = new StructurePartsGenerationEvent(world, editor.getDimension());
+      Dungeon.generateInChunkIfPossible(editor, chunkX, chunkZ, eventBus, partsEventBus);
     });
   }
 }

--- a/roguelike-core/src/main/java/com/github/fnar/roguelike/events/GenerationEvents.java
+++ b/roguelike-core/src/main/java/com/github/fnar/roguelike/events/GenerationEvents.java
@@ -1,0 +1,12 @@
+package com.github.fnar.roguelike.events;
+
+import greymerk.roguelike.dungeon.settings.SettingIdentifier;
+import greymerk.roguelike.worldgen.Coord;
+
+public interface GenerationEvents {
+    void eventPre(SettingIdentifier id, Coord coord);
+
+    void eventPost(SettingIdentifier id, Coord coord);
+
+    boolean eventSuggest(SettingIdentifier id, Coord coord);
+}

--- a/roguelike-core/src/main/java/com/github/fnar/roguelike/events/GenerationPartsEvent.java
+++ b/roguelike-core/src/main/java/com/github/fnar/roguelike/events/GenerationPartsEvent.java
@@ -1,0 +1,8 @@
+package com.github.fnar.roguelike.events;
+
+import greymerk.roguelike.dungeon.settings.SettingIdentifier;
+
+public interface GenerationPartsEvent {
+
+    void eventParts(SettingIdentifier id, java.util.List<Float> coords);
+}

--- a/roguelike-core/src/main/java/greymerk/roguelike/dungeon/Dungeon.java
+++ b/roguelike-core/src/main/java/greymerk/roguelike/dungeon/Dungeon.java
@@ -1,6 +1,8 @@
 package greymerk.roguelike.dungeon;
 
 import com.github.fnar.minecraft.block.BlockType;
+import com.github.fnar.roguelike.events.GenerationEvents;
+import com.github.fnar.roguelike.events.GenerationPartsEvent;
 import com.github.fnar.util.ReportThisIssueException;
 import com.github.fnar.util.TimedCallable;
 import com.github.fnar.util.TimedTask;
@@ -52,6 +54,9 @@ public class Dungeon {
   private final List<DungeonLevel> levels = new ArrayList<>();
   private final WorldEditor editor;
 
+  private static GenerationEvents generationEvents;
+  private static GenerationPartsEvent generationPartsEvents;
+
   public Dungeon(WorldEditor editor) {
     this.editor = editor;
     try {
@@ -62,7 +67,9 @@ public class Dungeon {
     }
   }
 
-  public static void generateInChunkIfPossible(WorldEditor editor, int chunkX, int chunkZ) {
+  public static void generateInChunkIfPossible(WorldEditor editor, int chunkX, int chunkZ, GenerationEvents structureEvenBus, GenerationPartsEvent partsEventBus) {
+    generationEvents = structureEvenBus;
+    generationPartsEvents = partsEventBus;
     if (!isDungeonChunk(editor, chunkX, chunkZ)) {
       return;
     }
@@ -82,7 +89,9 @@ public class Dungeon {
       return;
     }
 
-    dungeon.timedGenerate(settings.get(), coord.get());
+    if (generationEvents.eventSuggest(settings.get().getId(), coord.get())) {
+      dungeon.timedGenerate(settings.get(), coord.get());
+    }
   }
 
   public static boolean isDungeonChunk(WorldEditor editor, int chunkX, int chunkZ) {
@@ -124,6 +133,7 @@ public class Dungeon {
   }
 
   public void timedGenerate(DungeonSettings dungeonSettings, Coord coord) {
+    generationEvents.eventPre(dungeonSettings.getId(), coord);
     new TimedTask("Dungeon.generate()", () -> generate(dungeonSettings, coord)).run();
   }
 
@@ -142,8 +152,11 @@ public class Dungeon {
           .flatMap(stage -> DungeonTaskRegistry.getInstance().getTasks(stage).stream())
           .forEach(task -> performTaskSafely(dungeonSettings, task));
 
+      generationEvents.eventPost(dungeonSettings.getId(), coord);
       logger.info("Successfully generated dungeon with id {} at {}.", dungeonSettings.getId(), coord);
-
+      for (DungeonLevel level : levels) {
+        level.getLevelBBActualAsync(generationPartsEvents, dungeonSettings.getId(), level.layout);
+      }
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/roguelike-core/src/main/java/greymerk/roguelike/dungeon/Dungeon.java
+++ b/roguelike-core/src/main/java/greymerk/roguelike/dungeon/Dungeon.java
@@ -22,6 +22,7 @@ import java.util.stream.IntStream;
 
 import greymerk.roguelike.config.RogueConfig;
 import greymerk.roguelike.dungeon.settings.DungeonSettings;
+import greymerk.roguelike.dungeon.settings.SettingIdentifier;
 import greymerk.roguelike.dungeon.settings.SettingsRandom;
 import greymerk.roguelike.dungeon.settings.SettingsResolver;
 import greymerk.roguelike.dungeon.settings.SpawnCriteria;
@@ -155,7 +156,7 @@ public class Dungeon {
       generationEvents.eventPost(dungeonSettings.getId(), coord);
       logger.info("Successfully generated dungeon with id {} at {}.", dungeonSettings.getId(), coord);
       for (DungeonLevel level : levels) {
-        level.getLevelBBActualAsync(generationPartsEvents, dungeonSettings.getId(), level.layout);
+        postLevelBoundingBoxEventAsync(level, generationPartsEvents, dungeonSettings.getId());
       }
     } catch (Exception e) {
       e.printStackTrace();
@@ -168,6 +169,12 @@ public class Dungeon {
     } catch (Exception exception) {
       new ReportThisIssueException(exception).printStackTrace();
     }
+  }
+
+  private static void postLevelBoundingBoxEventAsync(DungeonLevel dungeonLevel, GenerationPartsEvent eventBus, SettingIdentifier id) {
+    new Thread(() -> {
+      eventBus.eventParts(id, dungeonLevel.layout.getLevelBoundingBox());
+    }).start();
   }
 
   private Optional<Coord> selectLocation(Random rand, int x, int z) {

--- a/roguelike-core/src/main/java/greymerk/roguelike/dungeon/DungeonLevel.java
+++ b/roguelike-core/src/main/java/greymerk/roguelike/dungeon/DungeonLevel.java
@@ -1,6 +1,5 @@
 package greymerk.roguelike.dungeon;
 
-import com.github.fnar.roguelike.events.GenerationPartsEvent;
 import com.github.fnar.roguelike.worldgen.generatables.BaseGeneratable;
 import com.github.fnar.roguelike.worldgen.generatables.LadderPillar;
 import com.github.fnar.roguelike.worldgen.generatables.SpiralStaircase;
@@ -9,18 +8,13 @@ import greymerk.roguelike.dungeon.base.BaseRoom;
 import greymerk.roguelike.dungeon.base.RoomIterator;
 import greymerk.roguelike.dungeon.base.RoomType;
 import greymerk.roguelike.dungeon.layout.DungeonNode;
-import greymerk.roguelike.dungeon.layout.DungeonTunnel;
 import greymerk.roguelike.dungeon.layout.LevelLayout;
 import greymerk.roguelike.dungeon.settings.LevelSettings;
-import greymerk.roguelike.dungeon.settings.SettingIdentifier;
 import greymerk.roguelike.theme.Theme;
 import greymerk.roguelike.worldgen.Coord;
 import greymerk.roguelike.worldgen.WorldEditor;
 import greymerk.roguelike.worldgen.filter.Filter;
 import greymerk.roguelike.worldgen.filter.IFilter;
-
-import java.util.Arrays;
-import java.util.List;
 
 public class DungeonLevel {
 
@@ -138,29 +132,4 @@ public class DungeonLevel {
     return layout.containsRoomAt(coord);
   }
 
-  public void getLevelBBActualAsync(GenerationPartsEvent eventBus, SettingIdentifier id, LevelLayout layout) {
-    new Thread(() -> {
-      float maxX = Integer.MIN_VALUE;
-      float maxY = Integer.MIN_VALUE;
-      float maxZ = Integer.MIN_VALUE;
-      float minX = Integer.MAX_VALUE;
-      float minY = Integer.MAX_VALUE;
-      float minZ = Integer.MAX_VALUE;
-      for (DungeonTunnel tunnel : layout.getTunnels()) {
-        for (Coord tunnelCoords : tunnel.getTunnel()) {
-          float x = tunnelCoords.getX();
-          float y = tunnelCoords.getY();
-          float z = tunnelCoords.getZ();
-          if (x > maxX) maxX = x;
-          if (y > maxY) maxY = y;
-          if (z > maxZ) maxZ = z;
-          if (x < minX) minX = x;
-          if (y < minY) minY = y;
-          if (z < minZ) minZ = z;
-        }
-      }
-      List<Float> result = Arrays.asList(minX, minY, minZ, maxX, maxY, maxZ);
-      eventBus.eventParts(id, result);
-    }).start();
-  }
 }

--- a/roguelike-core/src/main/java/greymerk/roguelike/dungeon/DungeonLevel.java
+++ b/roguelike-core/src/main/java/greymerk/roguelike/dungeon/DungeonLevel.java
@@ -1,5 +1,6 @@
 package greymerk.roguelike.dungeon;
 
+import com.github.fnar.roguelike.events.GenerationPartsEvent;
 import com.github.fnar.roguelike.worldgen.generatables.BaseGeneratable;
 import com.github.fnar.roguelike.worldgen.generatables.LadderPillar;
 import com.github.fnar.roguelike.worldgen.generatables.SpiralStaircase;
@@ -8,13 +9,18 @@ import greymerk.roguelike.dungeon.base.BaseRoom;
 import greymerk.roguelike.dungeon.base.RoomIterator;
 import greymerk.roguelike.dungeon.base.RoomType;
 import greymerk.roguelike.dungeon.layout.DungeonNode;
+import greymerk.roguelike.dungeon.layout.DungeonTunnel;
 import greymerk.roguelike.dungeon.layout.LevelLayout;
 import greymerk.roguelike.dungeon.settings.LevelSettings;
+import greymerk.roguelike.dungeon.settings.SettingIdentifier;
 import greymerk.roguelike.theme.Theme;
 import greymerk.roguelike.worldgen.Coord;
 import greymerk.roguelike.worldgen.WorldEditor;
 import greymerk.roguelike.worldgen.filter.Filter;
 import greymerk.roguelike.worldgen.filter.IFilter;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class DungeonLevel {
 
@@ -130,5 +136,31 @@ public class DungeonLevel {
 
   public boolean containsRoomAt(Coord coord) {
     return layout.containsRoomAt(coord);
+  }
+
+  public void getLevelBBActualAsync(GenerationPartsEvent eventBus, SettingIdentifier id, LevelLayout layout) {
+    new Thread(() -> {
+      float maxX = Integer.MIN_VALUE;
+      float maxY = Integer.MIN_VALUE;
+      float maxZ = Integer.MIN_VALUE;
+      float minX = Integer.MAX_VALUE;
+      float minY = Integer.MAX_VALUE;
+      float minZ = Integer.MAX_VALUE;
+      for (DungeonTunnel tunnel : layout.getTunnels()) {
+        for (Coord tunnelCoords : tunnel.getTunnel()) {
+          float x = tunnelCoords.getX();
+          float y = tunnelCoords.getY();
+          float z = tunnelCoords.getZ();
+          if (x > maxX) maxX = x;
+          if (y > maxY) maxY = y;
+          if (z > maxZ) maxZ = z;
+          if (x < minX) minX = x;
+          if (y < minY) minY = y;
+          if (z < minZ) minZ = z;
+        }
+      }
+      List<Float> result = Arrays.asList(minX, minY, minZ, maxX, maxY, maxZ);
+      eventBus.eventParts(id, result);
+    }).start();
   }
 }

--- a/roguelike-core/src/main/java/greymerk/roguelike/dungeon/layout/DungeonTunnel.java
+++ b/roguelike-core/src/main/java/greymerk/roguelike/dungeon/layout/DungeonTunnel.java
@@ -38,6 +38,10 @@ public class DungeonTunnel implements Iterable<Coord>, Bounded {
     segments = new ArrayList<>();
   }
 
+  public List<Coord> getTunnel() {
+    return tunnel;
+  }
+
   @Override
   public Iterator<Coord> iterator() {
     return tunnel.iterator();

--- a/roguelike-core/src/main/java/greymerk/roguelike/dungeon/layout/LevelLayout.java
+++ b/roguelike-core/src/main/java/greymerk/roguelike/dungeon/layout/LevelLayout.java
@@ -1,6 +1,7 @@
 package greymerk.roguelike.dungeon.layout;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -140,4 +141,38 @@ public class LevelLayout {
     return getNodes().stream().anyMatch(node -> node.contains(coord));
   }
 
+  public List<Float> getLevelBoundingBox() {
+    float maxX = Integer.MIN_VALUE;
+    float maxY = Integer.MIN_VALUE;
+    float maxZ = Integer.MIN_VALUE;
+    float minX = Integer.MAX_VALUE;
+    float minY = Integer.MAX_VALUE;
+    float minZ = Integer.MAX_VALUE;
+    for (DungeonTunnel tunnel : getTunnels()) {
+      for (Coord tunnelCoords : tunnel.getTunnel()) {
+        float x = tunnelCoords.getX();
+        float y = tunnelCoords.getY();
+        float z = tunnelCoords.getZ();
+        if (x > maxX) {
+          maxX = x;
+        }
+        if (y > maxY) {
+          maxY = y;
+        }
+        if (z > maxZ) {
+          maxZ = z;
+        }
+        if (x < minX) {
+          minX = x;
+        }
+        if (y < minY) {
+          minY = y;
+        }
+        if (z < minZ) {
+          minZ = z;
+        }
+      }
+    }
+    return Arrays.asList(minX, minY, minZ, maxX, maxY, maxZ);
+  }
 }


### PR DESCRIPTION
 This way other mods and internal components can be notified of a generation through the forge event bus.

Added the following general events:
These contain information on the dungeons world, start coordinate, dimension and dungeon ID.

- SuggestGen
Posted when the generator considers generating a dungeon, can be cancelled to cancel the dungeon generation.

- Pre
Posted just before the dungeon starts generating.

- Post
Posted after the dungeon finished generating.

I also added an event for the generation of the dungeons layers, to get their coordinate information. 
(This one is important for me xD)

- eventParts
Posted after a dungeon finished generating. Contains the actual BB of one of the dungeons levels.